### PR TITLE
Wait for compose stack to restart with oci-env db reset

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,11 @@ jobs:
       - name: Wait for the stack to spin up
         run: |
           sleep 100
-      
+
+      - name: Test DB Reset
+        run: |
+          oci-env db reset
+
       - name: Test that the correct plugins are installed and that the API_ROOT was successfully changed.
         run: |
           curl localhost:5001/my/custom/api/api/v3/status/ | jq -r ".versions" | grep pulpcore


### PR DESCRIPTION
```
dnewswan-mac:oci_env dnewswan$ oci-env db reset

You have requested a database reset.
This will IRREVERSIBLY DESTROY
ALL data in the database "pulp".
Are you sure you want to do this?

Type 'yes' to continue, or 'no' to cancel: pulp [None]: root:INFO: Executing... "DROP DATABASE "pulp";"
pulp [None]: root:INFO: Executing... "CREATE DATABASE "pulp" WITH OWNER = "postgres"  ENCODING = 'UTF8';"
Reset successful.
Restarting oci_env_pulp_1  ... done
Restarting oci_env__base_1 ... done
Waiting for API to restart (attempt 1 of 10)
Waiting for API to restart (attempt 2 of 10)
Waiting for API to restart (attempt 3 of 10)
Waiting for API to restart (attempt 4 of 10)
Waiting for API to restart (attempt 5 of 10)
Back online
```