### PR TITLE
Fix error when using `oci-env exec` with docker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,15 @@ jobs:
     
       - name: Test profile custom compose definitions
         run: curl localhost:8002 | grep test
+      
+      - name: Print settings 
+        run: oci-env exec dynaconf list
+
+      - name: Pass service name to exec
+        run: oci-env exec -s pulp ls
+
+      - name: Pass service name + number to exec
+        run: oci-env exec -s pulp_1 ls
 
       - name: Print server logs
         if: always()

--- a/client/oci_env/utils.py
+++ b/client/oci_env/utils.py
@@ -236,24 +236,53 @@ class Compose:
         else:
             return subprocess.run(cmd, capture_output=pipe_output)
 
-    @property
-    def container_name(self):
+    def container_name(self, service=None):
         """Docker compose name containers using `-` while podman uses `_`
 
-        docker|podman ps -q --format '{{.Names}}' | grep oci_env | grep pulp
+        Underlying bash code:
+            binary ps -q --filter name=oci_env
+            --format '{{.Names}}' | grep env | grep -E '.1$'
         """
         binary = self.config["COMPOSE_BINARY"]
-        cmd = [
-            binary, "ps", "-q",
-            "--filter", f"name={self.config['COMPOSE_PROJECT_NAME']}",
-            "--format", "{{.Names}}",
-        ]
+        service = service or self.config["API_CONTAINER"]
+        project_name = self.config['COMPOSE_PROJECT_NAME']
+
+        def _exit_no_container_found():
+            service_name = service if service[-1].isdigit() else f"{service}_1"
+            name = f"{project_name}_{service_name}"
+            print(
+                f"Could not find a running container named: {name} \n"
+                f"instead of {service!r} did you mean 'pulp' or 'ui'?\n"
+                "Run `oci-env compose ps` to see all running containers."
+            )
+            exit(1)
+
+        def _service_containers():
+            """# Grep for the service name. e.g: pulp"""
+            return subprocess.Popen(
+                ("grep", service),
+                stdin=running_containers.stdout,
+                stdout=subprocess.PIPE
+            )
+
+        # List all containers that match the PROJECT_NAME pattern. e.g: oci_env
+        cmd = [binary, "ps", "-q", "--filter", f"name={project_name}", "--format", "{{.Names}}"]
         running_containers = subprocess.Popen(cmd, stdout=subprocess.PIPE)
 
-        return subprocess.check_output(
-            ("grep", "pulp"),
-            stdin=running_containers.stdout
-        ).decode("utf-8").strip()
+        # Does the user passed a specific container number? e.g: `oci-env exec -s pulp-2 ls`
+        if service[-1].isdigit():
+            container_name = _service_containers().stdout.read().decode("utf-8").strip().split("\n")[0]
+            if service in container_name:
+                return container_name
+
+        # Else grep only the container ending with `_1` or `-1` (the main service)
+        try:
+            return subprocess.check_output(
+                ("grep", '-E', ".1$"),
+                stdin=_service_containers().stdout
+            ).decode("utf-8").strip().split("\n")[0]
+        except subprocess.CalledProcessError:
+            _exit_no_container_found()
 
     def exec(self, args, service=None, interactive=False, pipe_output=False):
         """
@@ -264,15 +293,14 @@ class Compose:
         differs between podman-compose and docker-compose.
         """
         service = service or self.config["API_CONTAINER"]
-        project_name = self.config["COMPOSE_PROJECT_NAME"]
         binary = self.config["COMPOSE_BINARY"]
 
         # docker fails on systems with no interactive CLI. This tells docker
         # to use a pseudo terminal when no CLI is available.
         if os.getenv("COMPOSE_INTERACTIVE_NO_CLI", "0") == "1":
-            cmd = [binary, "exec", self.container_name] + args
+            cmd = [binary, "exec", self.container_name(service)] + args
         else:
-            cmd = [binary, "exec", "-it", self.container_name] + args
+            cmd = [binary, "exec", "-it", self.container_name(service)] + args
 
         if self.is_verbose:
             print(f"Running command in container: {' '.join(cmd)}")


### PR DESCRIPTION
```console
$ oci-env compose ps
NAME                COMMAND                  SERVICE             STATUS              PORTS
oci_env-_base-1     "/bin/true"              _base               exited (0)
oci_env-pulp-1      "/init"                  pulp                running             0.0.0.0:5001->5001/tcp, :::5001->5001/tcp
oci_env-ui-1        "docker-entrypoint.s…"   ui                  running             0.0.0.0:8002->8002/tcp, :::8002->8002/tcp

$ oci-env db reset
Error: No such container: oci_env_pulp_1
```

Looks like `docker-compose` names using `-` while `podman-compose` uses `_`

Fixes: #16