### PR TITLE
Support running integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,26 @@ oci-env test -i -p PLUGIN_NAME unit
 oci-env test -p PLUGIN_NAME unit
 ```
 
+### Integration
+
+```bash
+# Install the integration test dependencies for a plugin and run it.
+oci-env test -i -p PLUGIN_NAME integration
+
+# Run the integration tests for a plugin without installing test dependencies.
+oci-env test -p PLUGIN_NAME integration
+
+# When running user can specify extra pytest arguments such as
+# mark decorator
+oci-env test -p PLUGIN_NAME integration -m api_ui
+
+# select build (standalone, standalone-rbac, standalone-community, standalone-ldap, insights)
+oci-env test -p PLUGIN_NAME integration -b standalone
+
+# specific test
+oci-env test -p PLUGIN_NAME integration -k test_name
+```
+
 ## Profiles
 
 ### Custom Profiles

--- a/base/container_scripts/install_integration_requirements.sh
+++ b/base/container_scripts/install_integration_requirements.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+declare PROJECT=$1
+
+if [ ! -d "/src/$PROJECT/" ] 
+then
+    echo "Please clone $PROJECT into ../$PROJECT/"
+    exit 1
+fi
+
+cd /src/$PROJECT/
+
+if [[ -f integration_requirements.txt ]]; then
+    pip install -r integration_requirements.txt
+fi

--- a/base/container_scripts/run_integration_tests.sh
+++ b/base/container_scripts/run_integration_tests.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+declare PROJECT=$1
+declare MODE=$2
+declare TEST=$3
+declare BUILD=$4
+
+CONTENTAPPROVAL=$(cat /src/oci_env/.compose.env | grep PULP_GALAXY_REQUIRE_CONTENT_APPROVAL) 
+if [[ $CONTENTAPPROVAL != "PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=true" ]]; then
+    echo "The integration tests will not run correctly unless you set PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=true"
+    exit 1
+fi
+
+export HUB_USE_MOVE_ENDPOINT="true"
+export HUB_API_ROOT=http://localhost:5001/api/automation-hub/
+
+source /src/${OCI_ENV_DIRECTORY}/base/container_scripts/configure_pulp_smash.sh
+
+# Stop pulp services
+SERVICES=$(s6-rc -a list | egrep ^pulp)
+echo "$SERVICES" | xargs -I {} s6-rc -d change {}
+
+# Reset db and run migrations
+yes yes | pulpcore-manager reset_db --user postgres
+/etc/init/postgres-prepare
+
+# Restart services
+echo "$SERVICES" | xargs -I {} s6-rc -u change {}
+s6-rc -u change nginx
+
+# Load data
+pulpcore-manager shell_plus < src/$PROJECT/dev/common/setup_test_data.py
+
+cd /src/$PROJECT/
+
+test_settings=$(case $MODE in
+    (standalone) echo "not cloud_only and not community_only and not rbac_roles";;
+    (standalone-rbac) echo "rbac_roles";;
+    (standalone-community) echo "community_only";;
+    (standalone-ldap) echo "standalone_only and ldap";;
+    (insights) echo "not standalone_only and not community_only and not rbac_roles";;
+esac)
+
+if [[ $TEST != "" ]]; then # specific test
+    pytest --capture=no -k "$TEST" -v galaxy_ng/tests/integration
+elif [[ $BUILD != "" ]]; then # galaxy_ng build (standalone, standalone-rbac, standalone-community, standalone-ldap, insights)
+    pytest --capture=no -m "$test_settings" -v galaxy_ng/tests/integration
+elif [[ $MODE != "" ]]; then # run tests with mark decorator (-m)
+    pytest --capture=no -m "$MODE" -v galaxy_ng/tests/integration
+else 
+    pytest --capture=no -v galaxy_ng/tests/integration
+fi

--- a/client/oci_env/commands.py
+++ b/client/oci_env/commands.py
@@ -79,7 +79,7 @@ def test(args, client):
         exit_if_failed(
             client.exec_container_script(
                 f"run_{args.test}_tests.sh",
-                args=[args.plugin] + args.args,
+                args=[args.plugin, args.mode, args.key, args.build] + args.args,
                 interactive=True)
         )
 

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -61,10 +61,13 @@ def parse_shell_command(subparsers):
 
 def parse_test_command(subparsers):
     parser = subparsers.add_parser('test', help='Run tests and install requirements.')
-    parser.add_argument('test', choices=["functional", "unit", "lint"])
+    parser.add_argument('test', choices=["functional", "unit", "lint", "integration"])
     parser.add_argument('-i', action='store_true', dest='install_deps', help="Install the python dependencies for the selected test instead of running it. If -p is not specified this will install all the test dependencies for each plugin in DEV_SOURCE_PATH.")
     parser.add_argument('-p', type=str, default="", dest='plugin', help="Plugin to test. Tests won't run unless this is specified.")
-    parser.add_argument('args', nargs=argparse.REMAINDER, help='Arguments to pass to pytest.')
+    parser.add_argument('-b', dest="build", default="", type=str, choices=["standalone", "standalone-rbac", "standalone-ldap", "standalone-community", "insights"])    
+    parser.add_argument('-m', dest="mode", default="", type=str)
+    parser.add_argument('-k', dest="key", default="", type=str, help="Select specific test by name")
+    parser.add_argument('args', nargs="*", help='Arguments to pass to pytest.')
     parser.set_defaults(func=test)
 
 


### PR DESCRIPTION
Allow running galaxy_ng integration tests

```
# Install the integration test dependencies for a plugin and run it.
oci-env test -i -p PLUGIN_NAME integration

# Run the integration tests for a plugin without installing test dependencies.
oci-env test -p PLUGIN_NAME integration

# When running user can specify extra pytest arguments such as
# mark decorator
oci-env test -p PLUGIN_NAME integration -m api_ui

# select build (standalone, standalone-rbac, standalone-community, standalone-ldap, insights)
oci-env test -p PLUGIN_NAME integration -b standalone

# specific test
oci-env test -p PLUGIN_NAME integration -k test_name
```

