### PR TITLE
Fix `pulp cli` for galaxy_ng config/profile

### DIFF
--- a/base/init.sh
+++ b/base/init.sh
@@ -2,9 +2,11 @@
 
 pulpcore-manager createsuperuser --no-input --email admin@example.com || true
 
+export PULP_API_ROOT="$(bash "/opt/oci_env/base/container_scripts/get_dynaconf_var.sh" API_ROOT)"
+
 if ! pulp --refresh-api status
 then
-  pulp config create --overwrite --base-url "http://localhost:${NGINX_PORT}" --username "${DJANGO_SUPERUSER_USERNAME}" --password "${DJANGO_SUPERUSER_PASSWORD}"
+  pulp config create --overwrite --base-url "http://localhost:${NGINX_PORT}" --api-root "${PULP_API_ROOT}" --username "${DJANGO_SUPERUSER_USERNAME}" --password "${DJANGO_SUPERUSER_PASSWORD}"
   if ! grep -q "_PULP_COMPLETE=bash_source pulp" /root/.bashrc
   then
     echo "eval \"\$(LC_ALL=C _PULP_COMPLETE=bash_source pulp)\"" >> /root/.bashrc

--- a/client/oci_env/commands.py
+++ b/client/oci_env/commands.py
@@ -157,5 +157,10 @@ def profile(args, client):
         except FileNotFoundError:
             exit_with_error(f"{args.profile} doesn't have a README.md")
 
+
 def poll(args, client):
     client.poll(args.attempts, args.wait)
+
+
+def pulp(args, client):
+    client.exec(["pulp"] + args.command, interactive=True)

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -10,7 +10,8 @@ from oci_env.commands import (
     generate_client,
     pulpcore_manager,
     profile,
-    poll
+    poll,
+    pulp
 )
 
 from oci_env.utils import (
@@ -34,6 +35,7 @@ def get_parser():
     parse_pulpcore_manager_command(subparsers)
     parse_profile_command(subparsers)
     parse_poll_command(subparsers)
+    parse_pulp_cli_command(subparsers)
 
     return parser
 
@@ -111,6 +113,12 @@ def parse_poll_command(subparsers):
     parser.add_argument('--attempts', type=int, dest='attempts', default=10, help="Number of attempts to make.")
     parser.add_argument('--wait', type=int, dest='wait', default=10, help="Time in seconds to wait between attempts.")
     parser.set_defaults(func=poll)
+
+
+def parse_pulp_cli_command(subparsers):
+    parser = subparsers.add_parser('pulp', help='Run pulp cli.')
+    parser.add_argument('command', nargs=argparse.REMAINDER, help='Command to pass to pulp cli.')
+    parser.set_defaults(func=pulp)
 
 
 def main():


### PR DESCRIPTION
[noissue]

Fixes API path for `galaxy_base` profile to enable using `pulp cli`.
Support running `pulp cli` with `oci_env` commands: `oci-env pulp <args>` (similar to the pulpcore-manager cmd) 

examples: 
- `oci-env pulp status`
- ` oci-env pulp debug openapi schema`