### PR TITLE
Install `pulp_smash` dependency for unit tests

### DIFF
--- a/base/container_scripts/install_unit_requirements.sh
+++ b/base/container_scripts/install_unit_requirements.sh
@@ -10,6 +10,8 @@ then
     exit 1
 fi
 
+pip install git+https://github.com/pulp/pulp-smash.git
+
 cd "/src/$PROJECT/"
 
 if [[ -f unittest_requirements.txt ]]; then


### PR DESCRIPTION
[no-issue]

With the rebuilt `oci_env`, when running unit tests first and without running functional tests before, `pulp_smash` and `pulpcore-client` are missing.

without `pulpcore` in `DEV_SOURCE_PATH`:
```
Traceback (most recent call last):
  File "/usr/local/bin/pytest", line 8, in <module>
    sys.exit(console_main())
  File "/usr/local/lib/python3.8/site-packages/_pytest/config/__init__.py", line 190, in console_main
    code = main()
    ...
  File "/usr/local/lib/python3.8/site-packages/_pytest/assertion/rewrite.py", line 168, in exec_module
    exec(co, module.__dict__)
  File "/usr/local/lib/python3.8/site-packages/pulpcore/tests/functional/__init__.py", line 5, in <module>
    from pulp_smash.config import get_config
ModuleNotFoundError: No module named 'pulp_smash'
```
`pulpcore` included in `DEV_SOURCE_PATH`:
```
  ...
  File "/src/pulpcore/pulpcore/tests/functional/__init__.py", line 9, in <module>
    from pulp_smash.config import get_config
ModuleNotFoundError: No module named 'pulp_smash'
```

The issue comes from `pulpcore/tests/functional/__init__.py`, so this bubbles into all other modules using `pulpcore`