### PR TITLE
Add db snapshot and restore commands.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,9 +109,6 @@ jobs:
           if oci-env exec pulp file repository show --name test1; then false; fi
           if oci-env exec pulp file repository show --name test2; then false; fi
 
-      - name: Verify test data is gone
-        run: curl localhost:5001/my/custom/api/api/v3/repositories/file/file/ | jq -r ".versions" | grep pulpcore
-
       - name: Test that the correct plugins are installed and that the API_ROOT was successfully changed.
         run: |
           curl localhost:5001/my/custom/api/api/v3/status/ | jq -r ".versions" | grep pulpcore

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,9 +88,29 @@ jobs:
           oci-env poll --wait 15 --attempts 30
           oci-env -e custom.env poll --wait 5 --attempts 5
 
-      - name: Test DB Reset
+      - name: Create some dummy data with the pulp CLI
+        run: oci-env exec pulp file repository create --name test1
+      
+      - name: Snapshot the DB
+        run: oci-env db snapshot
+
+      - name: Create some dummy data with the pulp CLI
+        run: oci-env exec pulp file repository create --name test2
+
+      - name: Test DB restore. Test that test1 exists and test2 doesn't
+        run: | 
+          oci-env db restore
+          oci-env exec pulp file repository show --name test1
+          if oci-env exec pulp file repository show --name test2; then false; fi
+
+      - name: Test DB Reset. Test that test1 and test2 are gone
         run: |
           oci-env db reset
+          if oci-env exec pulp file repository show --name test1; then false; fi
+          if oci-env exec pulp file repository show --name test2; then false; fi
+
+      - name: Verify test data is gone
+        run: curl localhost:5001/my/custom/api/api/v3/repositories/file/file/ | jq -r ".versions" | grep pulpcore
 
       - name: Test that the correct plugins are installed and that the API_ROOT was successfully changed.
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,25 +89,25 @@ jobs:
           oci-env -e custom.env poll --wait 5 --attempts 5
 
       - name: Create some dummy data with the pulp CLI
-        run: oci-env exec pulp file repository create --name test1
+        run: oci-env pulp file repository create --name test1
       
       - name: Snapshot the DB
         run: oci-env db snapshot
 
       - name: Create some dummy data with the pulp CLI
-        run: oci-env exec pulp file repository create --name test2
+        run: oci-env pulp file repository create --name test2
 
       - name: Test DB restore. Test that test1 exists and test2 doesn't
         run: | 
           oci-env db restore
-          oci-env exec pulp file repository show --name test1
-          if oci-env exec pulp file repository show --name test2; then false; fi
+          oci-env pulp file repository show --name test1
+          if oci-env pulp file repository show --name test2; then false; fi
 
       - name: Test DB Reset. Test that test1 and test2 are gone
         run: |
           oci-env db reset
-          if oci-env exec pulp file repository show --name test1; then false; fi
-          if oci-env exec pulp file repository show --name test2; then false; fi
+          if oci-env pulp file repository show --name test1; then false; fi
+          if oci-env pulp file repository show --name test2; then false; fi
 
       - name: Test that the correct plugins are installed and that the API_ROOT was successfully changed.
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 .compiled
-db_snapshots
 profiles/*_local/
 *compose.env
-db_back/
+db_backup/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 db_snapshots
 profiles/*_local/
 *compose.env
+db_back/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/base/container_scripts/db_restore.sh
+++ b/base/container_scripts/db_restore.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+declare FILENAME="$1"
+
+set -e
+
+# stop pulp services
+SERVICES=$(s6-rc -a list | grep -E ^pulp)
+echo "$SERVICES" | xargs -I {} s6-rc -d change {}
+
+echo "extracting $FILENAME.tar.gz to /var/lib/pulp"
+tar --overwrite -xzf /opt/oci_env/db_back/$FILENAME.tar.gz -C /var/lib/pulp/
+
+echo "restoring database"
+pg_restore --clean -U pulp -d pulp "/var/lib/pulp/pulp_db.backup"
+
+# restart the servicees
+echo "$SERVICES" | xargs -I {} s6-rc -u change {}
+s6-rc -u change nginx

--- a/base/container_scripts/db_restore.sh
+++ b/base/container_scripts/db_restore.sh
@@ -9,7 +9,7 @@ SERVICES=$(s6-rc -a list | grep -E ^pulp)
 echo "$SERVICES" | xargs -I {} s6-rc -d change {}
 
 echo "extracting $FILENAME.tar.gz to /var/lib/pulp"
-tar --overwrite -xzf /opt/oci_env/db_back/$FILENAME.tar.gz -C /var/lib/pulp/
+tar --overwrite -xzf /opt/oci_env/db_backup/$FILENAME.tar.gz -C /var/lib/pulp/
 
 echo "restoring database"
 pg_restore --clean -U pulp -d pulp "/var/lib/pulp/pulp_db.backup"

--- a/base/container_scripts/db_restore.sh
+++ b/base/container_scripts/db_restore.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
+set -eu
 
 declare FILENAME="$1"
-
-set -e
 
 # stop pulp services
 SERVICES=$(s6-rc -a list | grep -E ^pulp)

--- a/base/container_scripts/db_snapshot.sh
+++ b/base/container_scripts/db_snapshot.sh
@@ -4,10 +4,10 @@ declare FILENAME="$1"
 
 set -e
 
-mkdir -p /opt/oci_env/db_back/
+mkdir -p /opt/oci_env/db_backup/
 
 echo "dumping database to /var/lib/pulp"
 pg_dump -U pulp -F c -b -f "/var/lib/pulp/pulp_db.backup" 
 
 echo "archiving /var/lib/pulp to $FILENAME.tar.gz"
-tar -czf /opt/oci_env/db_back/$FILENAME.tar.gz -C /var/lib/pulp .
+tar -czf /opt/oci_env/db_backup/$FILENAME.tar.gz -C /var/lib/pulp .

--- a/base/container_scripts/db_snapshot.sh
+++ b/base/container_scripts/db_snapshot.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+declare FILENAME="$1"
+
+set -e
+
+mkdir -p /opt/oci_env/db_back/
+
+echo "dumping database to /var/lib/pulp"
+pg_dump -U pulp -F c -b -f "/var/lib/pulp/pulp_db.backup" 
+
+echo "archiving /var/lib/pulp to $FILENAME.tar.gz"
+tar -czf /opt/oci_env/db_back/$FILENAME.tar.gz -C /var/lib/pulp .

--- a/client/oci_env/commands.py
+++ b/client/oci_env/commands.py
@@ -11,7 +11,7 @@ def compose(args, client):
 
 
 def exec(args, client):
-    client.exec(args.command, interactive=True, service=args.service)
+    exit_if_failed(client.exec(args.command, interactive=True, service=args.service))
 
 
 def db(args, client):
@@ -23,7 +23,23 @@ def db(args, client):
                 args=None,
                 interactive=True)
         )
+        client.poll(10, 5)
 
+    elif action == 'snapshot':
+        exit_if_failed(
+            client.exec_container_script(
+                f"db_snapshot.sh",
+                args=[args.filename, ],
+                interactive=True)
+        )
+
+    elif action == 'restore':
+        exit_if_failed(
+            client.exec_container_script(
+                f"db_restore.sh",
+                args=[args.filename, ],
+                interactive=True)
+        )
         client.poll(10, 5)
 
     else:

--- a/client/oci_env/commands.py
+++ b/client/oci_env/commands.py
@@ -179,4 +179,4 @@ def poll(args, client):
 
 
 def pulp(args, client):
-    client.exec(["pulp"] + args.command, interactive=True)
+    exit(client.exec(["pulp"] + args.command, interactive=False).returncode)

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -61,7 +61,7 @@ def parse_db_command(subparsers):
         type=str,
         default="pulp_backup",
         dest='filename',
-        help=('Back up or restore the database and artifacts to a file in OCI_ENV_PATH/db_back/')
+        help=('Back up or restore the database and artifacts to a file in OCI_ENV_PATH/db_backup/')
     )
     parser.set_defaults(func=db)
 

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -55,9 +55,14 @@ def parse_exec_command(subparsers):
 
 def parse_db_command(subparsers):
     parser = subparsers.add_parser('db', help='Manage the application DB.')
-    # parser.add_argument('action', nargs='?', choices=["reset", "snapshot", "restore"])
-    parser.add_argument('action', nargs=1, choices=["reset"])
-    # parser.add_argument('-f', type=str, default="db.backup", dest='restore_file', help='Back up the database to a specific file.')
+    parser.add_argument('action', nargs=1, choices=["reset", "snapshot", "restore"])
+    parser.add_argument(
+        '-f',
+        type=str,
+        default="pulp_backup",
+        dest='filename',
+        help=('Back up or restore the database and artifacts to a file in OCI_ENV_PATH/db_back/')
+    )
     parser.set_defaults(func=db)
 
 


### PR DESCRIPTION
Add db snapshot and db restore commands to snapshot and restore postgres and /var/lib/pulp/.

```
oci-env db -h
usage: oci-env db [-h] [-f FILENAME] {reset,snapshot,restore}

positional arguments:
  {reset,snapshot,restore}

optional arguments:
  -h, --help            show this help message and exit
  -f FILENAME           Back up or restore the database and artifacts to a file in OCI_ENV_PATH/db_back/
```