### PR TITLE
Disable mac CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,8 @@ jobs:
             TEST: docker
           - os: ubuntu-latest
             TEST: podman
-          - os: macos-12
-            TEST: docker
+          # - os: macos-12
+          #   TEST: docker
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The Mac OS CI has been super slow and unreliable to the point where it's becoming more of a deterrent than useful.