### PR TITLE
Taught oci_env about the possible existence of 'performance' tests.

### DIFF
--- a/base/container_scripts/install_performance_requirements.sh
+++ b/base/container_scripts/install_performance_requirements.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+declare PROJECT="$1"
+
+if [ ! -d "/src/$PROJECT/" ]
+then
+    echo "Please clone $PROJECT into ../$PROJECT/"
+    exit 1
+fi
+
+cd "/src/$PROJECT/"
+
+if [[ -f perftest_requirements.txt ]]; then
+    pip install -r perftest_requirements.txt
+elif [[ -f functest_requirements.txt ]]; then
+    pip install -r functest_requirements.txt
+fi

--- a/base/container_scripts/run_performance_tests.sh
+++ b/base/container_scripts/run_performance_tests.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+declare PACKAGE="$1"
+declare PROJECT="${PACKAGE//-/_}"
+
+set -e
+
+function check_pytest () {
+    sudo -u pulp -E type pytest || {
+        cat << EOF
+
+ERROR: pytest is not installed
+
+This usually means you did not include the "-i" flag with the oci-env "test"
+subcommand. The first invocation of functional tests needs "-i" to install the
+test requirements (inc. pytest). After the requirements are installed, "-i" can
+be dropped from further runs on the same container instance.
+EOF
+        exit 1
+    }
+}
+
+function check_client () {
+    sudo -u pulp -E python3 -c "import pulpcore.client.${PROJECT}" || {
+        cat << EOF
+
+ERROR: pulpcore.client.${PROJECT} is missing.
+
+This usually means you did not run "oci-env generate-client -i ${PROJECT}" before
+running the functional test command. It could also mean you did not pass the "-i"
+flag to the "generate-client" subcommand which would have created the client, but
+not install it into the appropriate location.
+EOF
+        exit 1
+    }
+}
+
+source "/opt/oci_env/base/container_scripts/configure_pulp_smash.sh"
+
+cd "/src/$PACKAGE/"
+
+check_pytest
+check_client
+
+sudo -u pulp -E pytest -r sx --rootdir=/var/lib/pulp --color=yes --pyargs "$PROJECT.tests.performance" "${@:2}"

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -80,7 +80,7 @@ def parse_shell_command(subparsers):
 
 def parse_test_command(subparsers):
     parser = subparsers.add_parser('test', help='Run tests and install requirements.')
-    parser.add_argument('test', choices=["functional", "unit", "lint"])
+    parser.add_argument('test', choices=["functional", "unit", "lint", "performance"])
     parser.add_argument('-i', action='store_true', dest='install_deps', help="Install the python dependencies for the selected test instead of running it. If -p is not specified this will install all the test dependencies for each plugin in DEV_SOURCE_PATH.")
     parser.add_argument('-p', type=str, default="", dest='plugin', help="Plugin to test. Tests won't run unless this is specified.")
     parser.add_argument('args', nargs=argparse.REMAINDER, help='Arguments to pass to pytest.')


### PR DESCRIPTION
See pulp_rpm/tests/performance, for example.

Will install perfest_requirements if found, defaulting to functest_requirements if not.

closes #106