### PR TITLE
Remove the modified `run` file and uses the standard way to run pulp.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -18,6 +18,4 @@ RUN cd /etc/s6-overlay/s6-rc.d/user/contents.d && touch oci-env-prepare oci-env-
 # Modify postgres so it starts after oci-env gets a chance to initialize the plugins from source
 COPY s6-rc-modifications/postgres-prepare/dependencies.d /etc/s6-overlay/s6-rc.d/postgres-prepare/dependencies.d
 
-# Modify pulpcore-api so it auto reloads
-COPY s6-rc-modifications/pulpcore-api/run /etc/s6-overlay/s6-rc.d/pulpcore-api/run
 COPY utils.sh /utils.sh


### PR DESCRIPTION
Closes #95
