### PR TITLE
Use pip3 for `install_client.sh` and `functest_requirements.txt`

### DIFF
--- a/base/container_scripts/install_client.sh
+++ b/base/container_scripts/install_client.sh
@@ -6,4 +6,4 @@ declare PROJECT="$1"
 
 cd "/src/pulp-openapi-generator/$PROJECT-client"
 
-pip install -e .
+pip3 install -e .

--- a/base/container_scripts/install_functional_requirements.sh
+++ b/base/container_scripts/install_functional_requirements.sh
@@ -13,5 +13,5 @@ fi
 cd "/src/$PROJECT/"
 
 if [[ -f functest_requirements.txt ]]; then
-    pip install -r functest_requirements.txt
+    pip3 install -r functest_requirements.txt
 fi

--- a/base/dev_requirements.txt
+++ b/base/dev_requirements.txt
@@ -4,5 +4,5 @@ epdb
 py-spy
 pydevd_pycharm
 django-extensions
-pulp-cli
+pulp-cli==0.20.2
 pulp-cli-deb


### PR DESCRIPTION
[noissue]

Python packages get installed in different repositories. pip installs repositories to Python 3.8 repository, while pip3 installs to Python 3.11.

When running `oci-env generate-client -i` or `oci-env test -i -p pulp_ansible functional`, requirements and packages are installed in different repositories and don't see each other.

```
[root@457fa361fd99 /]# pip list | grep pulp
pulp-ansible-client 0.19.0.dev0 /src/pulp-openapi-generator/pulp_ansible-client
pulp-cli            0.20.2
pulp-cli-deb        0.0.4
pulp-glue           0.20.2
pulpcore-client     3.30.0.dev0 /src/pulp-openapi-generator/pulpcore-client
```
```
[root@457fa361fd99 /]# pip3 list | grep pulp
pulp-ansible                             0.19.0.dev0 /src/pulp_ansible
pulp-container                           2.16.0
pulp-glue                                0.20.3
pulpcore                                 3.30.0.dev0 /src/pulpcore
```

Adding pip3 ensures that it gets installed for Python 3.11.

The pip <cmd> command defaults to Python 3.8, while pip3 defaults to Python 3.11.
```
[root@457fa361fd99 /]# pip --version
pip 23.1.2 from /usr/local/lib/python3.8/site-packages/pip (python 3.8)
```

```
[root@457fa361fd99 /]# pip3 --version
pip 22.3.1 from /usr/lib/python3.11/site-packages/pip (python 3.11)
```

(we could do `pip3.11`, but this could break for older versions, since they don't have python 3.11)
