### PR TITLE
Allow environment overrides in config and add more debug logging.

### DIFF
--- a/client/oci_env/commands.py
+++ b/client/oci_env/commands.py
@@ -2,15 +2,18 @@ import subprocess
 import os
 import pathlib
 
+from oci_env.logger import logger
 from oci_env.utils import exit_if_failed, exit_with_error
 from oci_env.templates import profile_templates
 
 
 def compose(args, client):
+    logger.info(f'COMPOSE {args}')
     client.compose_command(args.command, interactive=True)
 
 
 def exec(args, client):
+    logger.info(f'EXEC {args}')
     exit_if_failed(client.exec(args.command, interactive=True, service=args.service))
 
 

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+
 from distutils.command.config import config
 
 from oci_env.commands import (
@@ -19,9 +21,28 @@ from oci_env.utils import (
 )
 
 
+def get_env_bool(key, default=False):
+    if key not in os.environ:
+        return default
+
+    val = os.environ.get(key)
+    if val is None:
+        return False
+
+    # truthy
+    if val.lower().strip() in ['yes', 'true', '1']:
+        return True
+
+    # falsy
+    if val.lower().strip() in ['no', 'false', '0', 'null', 'none', '']:
+        return False
+
+    return default
+
+
 def get_parser():
     parser = argparse.ArgumentParser(description='Pulp OCI image developer environment.')
-    parser.add_argument('-v', action='store_true', dest='is_verbose', help="Print extra debug information.")
+    parser.add_argument('-v', action='store_true', dest='is_verbose', default=get_env_bool("OCI_VERBOSE"), help="Print extra debug information.")
     parser.add_argument('-e', type=str, default="", dest='env_file', help="Specify an environment file to use other than the default.")
 
     subparsers = parser.add_subparsers()
@@ -143,6 +164,7 @@ def main():
         parser.print_help()
         exit()
 
+    import epdb; epdb.st()
     client = Compose(args.is_verbose, args.env_file)
     try:
         args.func(args, client)

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -164,7 +164,6 @@ def main():
         parser.print_help()
         exit()
 
-    import epdb; epdb.st()
     client = Compose(args.is_verbose, args.env_file)
     try:
         args.func(args, client)

--- a/client/oci_env/utils.py
+++ b/client/oci_env/utils.py
@@ -133,7 +133,6 @@ def get_config(env_file):
             cfg[key] = val
         else:
             val = cfg[key]
-        logger.info(f'OCI-ENV cfg {key}={val}')
 
     return cfg
 
@@ -338,6 +337,10 @@ class Compose:
         self.config = get_config(get_env_file(self.path, env_file))
         self.compose_files = parse_profiles(self.config)
         self.is_verbose = is_verbose
+
+        if self.is_verbose:
+            for key in sorted(self.config.keys()):
+                logger.info(f'OCI CFG {key} = {self.config[key]}')
 
     def compose_command(self, cmd, interactive=False, pipe_output=False):
         """

--- a/client/oci_env/utils.py
+++ b/client/oci_env/utils.py
@@ -123,9 +123,19 @@ def get_config(env_file):
         "WORKER_CONTAINER": "pulp",
     }
 
-
     # override any defaults that the user set.
-    return {**config, **user_preferences, **constant_vals}
+    cfg = {**config, **user_preferences, **constant_vals}
+
+    # allow env overrides except for constants
+    for key in sorted(list(cfg.keys())):
+        if key in os.environ and key not in constant_vals:
+            val = os.environ.get(key)
+            cfg[key] = val
+        else:
+            val = cfg[key]
+        logger.info(f'OCI-ENV cfg {key}={val}')
+
+    return cfg
 
 
 def parse_profiles(config):
@@ -346,12 +356,13 @@ class Compose:
 
         cmd = binary + compose_files + cmd
 
-        if self.is_verbose:
-            logger.info(f"Running command in container: {' '.join(cmd)}")
-
         if interactive:
+            if self.is_verbose:
+                logger.info(f"Running [interactive] command in container: {' '.join(cmd)}")
             return subprocess.call(cmd)
         else:
+            if self.is_verbose:
+                logger.info(f"Running [non-interactive] command in container: {' '.join(cmd)}")
             return subprocess.run(cmd, capture_output=pipe_output)
 
     def container_name(self, service=None):
@@ -424,12 +435,13 @@ class Compose:
         if privileged:
             cmd = cmd[:2] + ["--privileged"] + cmd[2:]
 
-        if self.is_verbose:
-            logger.info(f"Running command in container: {' '.join(cmd)}")
-
         if interactive:
+            if self.is_verbose:
+                logger.info(f"Running [interactive] command in container: {' '.join(cmd)}")
             proc = subprocess.call(cmd)
         else:
+            if self.is_verbose:
+                logger.info(f"Running [non-interactive] command in container: {' '.join(cmd)}")
             proc = subprocess.run(cmd, capture_output=pipe_output)
         return proc
 


### PR DESCRIPTION
1) allow environment overrides in config

If I want to use multiple checkouts for my oci stack, I'd have to alter DEV_SOURCE_PATH within on of the files inside the profile. For quickly switching back and forth between those checkouts and the public pip installed packages or when trying to debug things, having to edit or find the right spot in the profile gets annoying. With this patch, we can instead do something like ...

```
DEV_SOURCE_PATH=pulpcore:pulp_ansible:galaxy_ng oci-env compose build
```

This is especially useful in galaxy_ng now that we have an "actionlib" wrapping around oci-env where most devs don't even know what all the moving parts are or where the relevant files reside.

2) more debug logging

oci-env does a lot of "magic" and it's mostly hidden from the user. We need it to display the various things it's doing with docker so that we can debug it, but also so that we can understand it.

3) OCI_VERBOSE env var can now set is_verbose

relevant to galaxy_ng's actionlib, where we can't control oci's verbosity because it's hidden inside a python subprocess call. It's difficult to debug 3 layers of subprocess calling if we can't turn OCI into verbose mode, so this allows us to do that.

```
OCI_VERBOSE=true make oci/insights
```