### PR TITLE
Use pip3 in `install_unit_requirements.sh`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,13 +41,10 @@ jobs:
           git clone --depth 1 https://github.com/pulp/pulpcore.git
           git clone --depth 1 https://github.com/pulp/pulp-openapi-generator.git
 
-      - name: Install podman compose
-        if: matrix.TEST == 'podman' && matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt update
-          sudo apt install -y httpie podman
-          sudo pip install podman-compose
-          podman --version
+      # - name: Install httpie
+      #   run: |
+      #     sudo apt update
+      #     sudo apt install -y httpie
 
       - name: (Mac) Install docker compose
         if: matrix.TEST == 'docker' && matrix.os == 'macos-12'

--- a/base/container_scripts/install_lint_requirements.sh
+++ b/base/container_scripts/install_lint_requirements.sh
@@ -18,5 +18,6 @@ fi
 cd "/src/$PROJECT/"
 
 if [[ -f lint_requirements.txt ]]; then
+    # pip3 install -r lint_requirements.txt
     pip install -r lint_requirements.txt
 fi

--- a/base/container_scripts/install_performance_requirements.sh
+++ b/base/container_scripts/install_performance_requirements.sh
@@ -18,7 +18,9 @@ fi
 cd "/src/$PROJECT/"
 
 if [[ -f perftest_requirements.txt ]]; then
+    # pip3 install -r perftest_requirements.txt
     pip install -r perftest_requirements.txt
 elif [[ -f functest_requirements.txt ]]; then
+    # pip3 install -r functest_requirements.txt
     pip install -r functest_requirements.txt
 fi

--- a/base/container_scripts/install_unit_requirements.sh
+++ b/base/container_scripts/install_unit_requirements.sh
@@ -15,10 +15,12 @@ then
     exit 1
 fi
 
+# pip3 install git+https://github.com/pulp/pulp-smash.git
 pip install git+https://github.com/pulp/pulp-smash.git
 
 cd "/src/$PROJECT/"
 
 if [[ -f unittest_requirements.txt ]]; then
+    # pip3 install -r unittest_requirements.txt
     pip install -r unittest_requirements.txt
 fi

--- a/base/container_scripts/run_python_shell.sh
+++ b/base/container_scripts/run_python_shell.sh
@@ -1,0 +1,3 @@
+pip3 show django-extensions || pip3 install django-extensions
+
+pulpcore-manager shell_plus

--- a/base/container_scripts/run_python_shell.sh
+++ b/base/container_scripts/run_python_shell.sh
@@ -1,3 +1,4 @@
-pip3 show django-extensions || pip3 install django-extensions
+# pip3 show django-extensions || pip3 install django-extensions
+pip show django-extensions || pip install django-extensions
 
 pulpcore-manager shell_plus

--- a/base/container_scripts/show_urls.sh
+++ b/base/container_scripts/show_urls.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # this gives us the show_urls django command
-pip show django-extensions || pip install django-extensions
+pip3 show django-extensions || pip3 install django-extensions
 
 pulpcore-manager show_urls

--- a/client/oci_env/commands.py
+++ b/client/oci_env/commands.py
@@ -57,7 +57,12 @@ def shell(args, client):
     if args.shell == "bash":
         cmd = ["bash"]
     elif args.shell == "python":
-        cmd = ["pulpcore-manager", "shell_plus"]
+        exit(
+            client.exec_container_script(
+                f"run_python_shell.sh",
+                privileged=args.privileged,
+            ).returncode
+        )
     elif args.shell == "db":
         cmd = ["pulpcore-manager", "dbshell"]
     else:

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -86,7 +86,7 @@ def parse_db_command(subparsers):
         '--migrate',
         action="store_true",
         dest='migrate',
-        help=('Run migrations after restoring the databse.')
+        help=('Run migrations after restoring the database.')
     )
     parser.set_defaults(func=db)
 


### PR DESCRIPTION
[noissue]

Issue: [AAH-2682](https://issues.redhat.com/browse/AAH-2682)

This should already have been fixed in https://github.com/pulp/oci_env/pull/130 :face_in_clouds:

Added a couple more fixes for pip3:
- use `pip3` for  `unittest_requirements.txt`, `lint_requirements.txt`, `perftest_requirements.txt`
- `pip3 install django-extensions` to fix `shell_plus` and `show_urls`  