### PR TITLE
Add possibility to overwrite base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/pulp/pulp-ci-centos:latest
+ARG BASE_IMAGE=ghcr.io/pulp/pulp-ci-centos:latest
+FROM $BASE_IMAGE
 
 # configure S6 to use env variables
 ENV S6_KEEP_ENV=1


### PR DESCRIPTION
```
oci-env compose build --build-arg BASE_IMAGE=foo
```

I am running oci env inside an CI environment and o not want to run into rate limiting

backwards compatibility is kept by setting default value.