### PR TITLE
Revert "Adds the `which` utility needed by some tests."

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,7 +7,6 @@ ENV S6_KEEP_ENV=1
 ENV XDG_CONFIG_HOME=/opt/settings
 
 COPY dev_requirements.txt /dev_requirements.txt
-RUN dnf install -y which
 
 COPY switch_python /usr/bin/switch_python
 ARG PYTHON_VERSION=3.8


### PR DESCRIPTION
This reverts commit 07ef2e28d371c970f8a8b4afb9f718ea966d574f.

It is no longer required to install `which` here because it is installed in the [base image](https://github.com/pulp/pulp-oci-images/blob/latest/images/Containerfile.core.base#L65)

I am running oci_env in CI environment and came across this when trying to improve build times it saves me 40s 

