### PR TITLE
Use module name (-m) to run pytest and pip

### DIFF
--- a/base/container_scripts/install_lint_requirements.sh
+++ b/base/container_scripts/install_lint_requirements.sh
@@ -18,5 +18,5 @@ fi
 cd "/src/$PROJECT/"
 
 if [[ -f lint_requirements.txt ]]; then
-    pip install -r lint_requirements.txt
+    python3 -m pip install -r lint_requirements.txt
 fi

--- a/base/container_scripts/install_performance_requirements.sh
+++ b/base/container_scripts/install_performance_requirements.sh
@@ -18,7 +18,7 @@ fi
 cd "/src/$PROJECT/"
 
 if [[ -f perftest_requirements.txt ]]; then
-    pip install -r perftest_requirements.txt
+    python3 -m pip install -r perftest_requirements.txt
 elif [[ -f functest_requirements.txt ]]; then
-    pip install -r functest_requirements.txt
+    python3 -m pip install -r functest_requirements.txt
 fi

--- a/base/container_scripts/install_unit_requirements.sh
+++ b/base/container_scripts/install_unit_requirements.sh
@@ -15,10 +15,10 @@ then
     exit 1
 fi
 
-pip install git+https://github.com/pulp/pulp-smash.git
+python3 -m pip install git+https://github.com/pulp/pulp-smash.git
 
 cd "/src/$PROJECT/"
 
 if [[ -f unittest_requirements.txt ]]; then
-    pip install -r unittest_requirements.txt
+    python3 -m pip install -r unittest_requirements.txt
 fi

--- a/base/container_scripts/run_functional_tests.sh
+++ b/base/container_scripts/run_functional_tests.sh
@@ -12,7 +12,7 @@ fi
 declare PROJECT="${PACKAGE//-/_}"
 
 function check_pytest () {
-    sudo -u pulp -E type pytest || {
+    sudo -u pulp -E python3 -m pytest --version || {
         cat << EOF
 
 ERROR: pytest is not installed
@@ -48,4 +48,4 @@ cd "/src/$PACKAGE/"
 check_pytest
 check_client
 
-sudo -u pulp -E pytest -r sx --rootdir=/var/lib/pulp --color=yes --pyargs "$PROJECT.tests.functional" "${@:2}"
+sudo -u pulp -E python3 -m pytest -r sx --rootdir=/var/lib/pulp --color=yes --pyargs "$PROJECT.tests.functional" "${@:2}"

--- a/base/container_scripts/run_performance_tests.sh
+++ b/base/container_scripts/run_performance_tests.sh
@@ -12,7 +12,7 @@ declare PROJECT="${PACKAGE//-/_}"
 set -e
 
 function check_pytest () {
-    sudo -u pulp -E type pytest || {
+    sudo -u pulp -E python3 -m pytest --version || {
         cat << EOF
 
 ERROR: pytest is not installed
@@ -48,4 +48,4 @@ cd "/src/$PACKAGE/"
 check_pytest
 check_client
 
-sudo -u pulp -E pytest -r sx --rootdir=/var/lib/pulp --color=yes --pyargs "$PROJECT.tests.performance" "${@:2}"
+sudo -u pulp -E python3 -m pytest -r sx --rootdir=/var/lib/pulp --color=yes --pyargs "$PROJECT.tests.performance" "${@:2}"

--- a/base/container_scripts/run_unit_tests.sh
+++ b/base/container_scripts/run_unit_tests.sh
@@ -15,4 +15,4 @@ source "/opt/oci_env/base/container_scripts/configure_pulp_smash.sh"
 
 cd "/src/$PACKAGE/"
 
-sudo -u pulp -E PULP_DATABASES__default__USER=postgres pytest -r sx --color=yes --pyargs "$PROJECT.tests.unit" "${@:2}"
+sudo -u pulp -E PULP_DATABASES__default__USER=postgres python3 -m pytest -r sx --color=yes --pyargs "$PROJECT.tests.unit" "${@:2}"

--- a/base/container_scripts/show_urls.sh
+++ b/base/container_scripts/show_urls.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # this gives us the show_urls django command
-pip show django-extensions || pip install django-extensions
+python3 -m pip show django-extensions || python3 -m pip install django-extensions
 
 pulpcore-manager show_urls


### PR DESCRIPTION
when using python version other than 3.8
pip and pytest were not using the correct python version