### PR TITLE
Update switch_python script to new default python version 3.9

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,7 +10,7 @@ ENV XDG_CONFIG_HOME=/opt/settings
 COPY dev_requirements.txt /dev_requirements.txt
 
 COPY switch_python /usr/bin/switch_python
-ARG PYTHON_VERSION=3.8
+ARG PYTHON_VERSION=3.9
 RUN switch_python "$PYTHON_VERSION"
 
 RUN pip3 install -r dev_requirements.txt

--- a/base/switch_python
+++ b/base/switch_python
@@ -3,8 +3,8 @@
 set -e
 
 NEWV=$1
-if [[ "$NEWV" == "3.8" ]]; then
-    echo "using default python 3.8"
+if [[ "$NEWV" == "3.9" ]]; then
+    echo "using default python 3.9"
     exit 0
 fi
 


### PR DESCRIPTION
With the oci_env now using the new centos9 images, the default python version is now 3.9. 

*Note* We can now publish other python version oci-images, but we haven't done so yet.