### PR TITLE
Docs fix - multiple Pulp instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ oci-env supports running multiple environments simultaneously. To do this, simpl
 COMPOSE_PROFILE=my_profiles
 DEV_SOURCE_PATH=pulpcore
 
-# These two values must be different from the port and project name for any other instances of the
-# environment that are running to avoid conflicts.
+# These three values must be different from the api port, docs port and project name for any other
+# instances of the environment that are running to avoid conflicts.
 API_PORT=4002
+DOCS_PORT=12346
 COMPOSE_PROJECT_NAME=test
 
 # If you want to use a different directory for your git checkouts you can set this

--- a/staging_docs/dev/guides/create-multiple-envs.md
+++ b/staging_docs/dev/guides/create-multiple-envs.md
@@ -11,9 +11,10 @@ You may place it in the root of `oci_env` dir:
 COMPOSE_PROFILE=my_profiles
 DEV_SOURCE_PATH=pulpcore
 
-# These two values must be different from the port and project name for any other instances of the
-# environment that are running to avoid conflicts.
+# These three values must be different from the api port, docs port and project name for any other
+# instances of the environment that are running to avoid conflicts.
 API_PORT=4002
+DOCS_PORT=12346
 COMPOSE_PROJECT_NAME=test
 
 # If you want to use a different directory for your git checkouts you can set this


### PR DESCRIPTION
The documentation did not mention that for running multiple Pulp instances, each instance must have not only different API_PORT and COMPOSE_PROJECT_NAME, but also different DOCS_PORT. This commit adds this information to the documentation and README.

[noissue]