### PR TITLE
always install docker-compose for the ubuntu integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,11 +56,15 @@ jobs:
         if: matrix.TEST == 'docker' && matrix.os == 'macos-12'
         uses: docker-practice/actions-setup-docker@1.0.11
 
+      #- name: (Linux) Install docker compose 
+      #  if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
+      #  uses: KengoTODA/actions-setup-docker-compose@v1
+      #  with:
+      #    version: '2.14.2' # the full version of `docker-compose` command
       - name: (Linux) Install docker compose 
         if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
-        uses: KengoTODA/actions-setup-docker-compose@v1
-        with:
-          version: '2.14.2' # the full version of `docker-compose` command
+        run: |
+          echo "skipping"
 
       - name: setup .compose.env files
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,15 +56,9 @@ jobs:
         if: matrix.TEST == 'docker' && matrix.os == 'macos-12'
         uses: docker-practice/actions-setup-docker@1.0.11
 
-      #- name: (Linux) Install docker compose 
-      #  if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
-      #  uses: KengoTODA/actions-setup-docker-compose@v1
-      #  with:
-      #    version: '2.14.2' # the full version of `docker-compose` command
       - name: (Linux) Install docker compose 
         if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
         run: |
-          # echo "skipping"
           curl -L -o /tmp/docker-compose https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-linux-x86_64
           install /tmp/docker-compose /usr/local/bin/
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,8 @@ jobs:
           podman --version
 
       - name: (Mac) Install docker compose
-        if: matrix.TEST == 'docker' && matrix.os == 'macos-12'
+        # if: matrix.TEST == 'docker' && matrix.os == 'macos-12'
+        if: matrix.TEST == 'docker'
         uses: docker-practice/actions-setup-docker@1.0.11
 
       - name: setup .compose.env files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,9 +53,14 @@ jobs:
           podman --version
 
       - name: (Mac) Install docker compose
-        # if: matrix.TEST == 'docker' && matrix.os == 'macos-12'
-        if: matrix.TEST == 'docker'
+        if: matrix.TEST == 'docker' && matrix.os == 'macos-12'
         uses: docker-practice/actions-setup-docker@1.0.11
+
+      - name: (Linux) Install docker compose 
+        if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
+        uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.14.2' # the full version of `docker-compose` command
 
       - name: setup .compose.env files
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
         run: |
           # echo "skipping"
-          curl -L -o /tmp/docker-compose https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-darwin-x86_64
+          curl -L -o /tmp/docker-compose https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-linux-x86_64
           install /tmp/docker-compose /usr/local/bin/
 
       - name: setup .compose.env files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,9 @@ jobs:
       - name: (Linux) Install docker compose 
         if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
         run: |
-          echo "skipping"
+          # echo "skipping"
+          curl -o /tmp/docker-compose https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-darwin-x86_64
+          install /tmp/docker-compose /usr/local/bin/
 
       - name: setup .compose.env files
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,11 +56,11 @@ jobs:
         if: matrix.TEST == 'docker' && matrix.os == 'macos-12'
         uses: docker-practice/actions-setup-docker@1.0.11
 
-      - name: (Linux) Install docker compose 
-        if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
-        uses: KengoTODA/actions-setup-docker-compose@v1
-        with:
-          version: '2.14.2' # the full version of `docker-compose` command
+      #- name: (Linux) Install docker compose 
+      #  if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
+      #  uses: KengoTODA/actions-setup-docker-compose@v1
+      #  with:
+      #    version: '2.14.2' # the full version of `docker-compose` command
 
       - name: setup .compose.env files
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,11 +56,11 @@ jobs:
         if: matrix.TEST == 'docker' && matrix.os == 'macos-12'
         uses: docker-practice/actions-setup-docker@1.0.11
 
-      #- name: (Linux) Install docker compose 
-      #  if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
-      #  uses: KengoTODA/actions-setup-docker-compose@v1
-      #  with:
-      #    version: '2.14.2' # the full version of `docker-compose` command
+      - name: (Linux) Install docker compose 
+        if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
+        uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: '2.14.2' # the full version of `docker-compose` command
 
       - name: setup .compose.env files
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.TEST == 'docker' && matrix.os == 'ubuntu-latest'
         run: |
           # echo "skipping"
-          curl -o /tmp/docker-compose https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-darwin-x86_64
+          curl -L -o /tmp/docker-compose https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-darwin-x86_64
           install /tmp/docker-compose /usr/local/bin/
 
       - name: setup .compose.env files


### PR DESCRIPTION
Github action workers are coming up sporadically without a docker-compose command. This could be due to a newer ubuntu that has finally deprecated the package, but i'm not exactly sure. In either case, this throws the upstream binary into /usr/local/bin so that it doesn't collide with anything in /usr/bin

NOTE:
Test failures are due to pulpcli dep issues per https://issues.redhat.com/browse/AAH-3335