### PR TITLE
Ignore dynaconf stderr and install gettext

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -15,6 +15,8 @@ RUN switch_python "$PYTHON_VERSION"
 
 RUN pip3 install -r dev_requirements.txt
 
+RUN dnf -y install gettext
+
 COPY settings.py /etc/pulp/settings.py
 COPY s6-rc.d/oci-env-prepare/ /etc/s6-overlay/s6-rc.d/oci-env-prepare/
 COPY s6-rc.d/oci-env-profiles /etc/s6-overlay/s6-rc.d/oci-env-profiles/

--- a/base/container_scripts/get_dynaconf_var.sh
+++ b/base/container_scripts/get_dynaconf_var.sh
@@ -1,1 +1,1 @@
-dynaconf get $1
+dynaconf get $1 2>/dev/null


### PR DESCRIPTION
These two issues are causing all galaxy oci-env based CI to fail polling checks.

1. One of our dependencies is emitting error messages to stderr when dynaconf runs, and the oci script is capturing that within the values it it trying to get. This shows up when the stack tries to get the API_ROOT from dynaconf and includes a bunch of errors in the result, then the poll fails because it's adding a bunch of junk to the url.
2. When the stack comes up, it tries to build translations which are dependant on gettext