### PR TITLE
Support setup for OSX

### DIFF
--- a/base/local_scripts/generate_client.sh
+++ b/base/local_scripts/generate_client.sh
@@ -18,7 +18,7 @@ cd ${SRC_DIR}/pulp-openapi-generator/
 export PULP_URL=${API_PROTOCOL}://${API_HOST}:${API_PORT}
 
 
-CONTAINER_LABEL=$(${COMPOSE_BINARY} container inspect ${COMPOSE_PROJECT_NAME}_pulp_1 | jq -r ".[0].ProcessLabel")
+CONTAINER_LABEL=$(${COMPOSE_BINARY} container inspect ${COMPOSE_PROJECT_NAME}-pulp-1 | jq -r ".[0].ProcessLabel")
 export PULP_MCS_LABEL=${CONTAINER_LABEL#'system_u:system_r:container_t:'}
 
 ./generate.sh $PROJECT $LANGUAGE

--- a/client/oci_env/utils.py
+++ b/client/oci_env/utils.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import subprocess
 import time
+import sys
 
 from urllib import request
 
@@ -345,6 +346,8 @@ class Compose:
         takes in the rest of the arguments (exec, up, down, etc) from the user.
         """
         binary = [self.config["COMPOSE_BINARY"] + "-compose", "-p", self.config["COMPOSE_PROJECT_NAME"]]
+        if sys.platform.lower() == "darwin" and self.config["COMPOSE_BINARY"] == "docker":
+            binary = [self.config["COMPOSE_BINARY"], "compose", "-p", self.config["COMPOSE_PROJECT_NAME"]]
 
         compose_files = []
 


### PR DESCRIPTION
Was also running into an error with the `oci-env generate-client` command, so fixed the container label in the `generate_client.sh` script.