### PR TITLE
Update CI to use the latest actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,9 @@ jobs:
         with:
           path: "oci_env"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-latest
     steps:
       - uses: "actions/checkout@v4"
       - name: "Set up Python"


### PR DESCRIPTION
This PR updates GH workflows to use the latest versions of actions and Python 3.11. See https://github.com/actions/runner-images/issues/11101 and https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ for more details.