### PR TITLE
Fix podman-compose hanging bug

### DIFF
--- a/base/compose.yaml
+++ b/base/compose.yaml
@@ -7,7 +7,8 @@ services:
       context: "{OCI_ENV_DIR}/base/"
       dockerfile: "Dockerfile"
     image: "localhost/oci_env/pulp:base"
-    entrypoint: "/bin/true"
+    # workaround for pulp service hanging while waiting for _base to be on running state
+    entrypoint: "/bin/sleep 1"
 
   pulp:
     image: "localhost/oci_env/pulp:base"


### PR DESCRIPTION
We have faced some hanging scenarios every now and then with oci_env.
This specific case happened to me on fedora 42 with podman-compose 1.4 and podman 5.5.

The problem is related to `_base` dummy service in base/compose.yaml (which is used only to build the local image) and its depends_on relationship. Podman was waiting it to be on a running state, but I think that when its too fast (the image is cached) the watcher misses it's chance.

The `/bin/true` command is used to mark the build has finished.
A adding a small delay instead of this appears to help podman see that it was in a running state.

---
obs: From what I've read, using `depends_on` for waiting on something that is not a service (doing a build, in our case) is actually not intended use for that feature. Ideally we should find an alternative way to achieve this build dependency thing.