### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ A developer environment for pulp based off of the [Pulp OCI Images](https://gith
 
 ## Getting started
 
-A detailed guide on setting up the development environment is available
-[here](staging_docs/dev/tutorials/quickstart.md).
+A detailed guide on setting up the development environment is available [here](docs/dev/tutorials/quickstart.md).
 
 ## Multiple environments
 


### PR DESCRIPTION
This PR fixes a link to the dev docs in the README, as `staging_docs` was renamed to `docs` in #183.