### PR TITLE
Fix generate_client getting the wrong container_name

### DIFF
--- a/base/local_scripts/generate_client.sh
+++ b/base/local_scripts/generate_client.sh
@@ -4,6 +4,7 @@ set -e
 
 declare PROJECT=$1
 declare LANGUAGE=$2
+declare CONTAINER_NAME=$3  # e.g, oci_env_pulp_1
 
 if [ ! -d "${SRC_DIR}/pulp-openapi-generator/" ]
 then
@@ -13,12 +14,12 @@ fi
 
 echo "Generating ${LANGUAGE}-client for ${PROJECT}."
 
-cd ${SRC_DIR}/pulp-openapi-generator/
+cd "${SRC_DIR}/pulp-openapi-generator/"
 
-export PULP_URL=${API_PROTOCOL}://${API_HOST}:${API_PORT}
+export PULP_URL="${API_PROTOCOL}://${API_HOST}:${API_PORT}"
 
 
-CONTAINER_LABEL=$(${COMPOSE_BINARY} container inspect ${COMPOSE_PROJECT_NAME}-pulp-1 | jq -r ".[0].ProcessLabel")
-export PULP_MCS_LABEL=${CONTAINER_LABEL#'system_u:system_r:container_t:'}
+CONTAINER_LABEL=$("${COMPOSE_BINARY}" container inspect "${CONTAINER_NAME}" | jq -r ".[0].ProcessLabel")
+export PULP_MCS_LABEL="${CONTAINER_LABEL#'system_u:system_r:container_t:'}"
 
-./generate.sh $PROJECT $LANGUAGE
+./generate.sh "$PROJECT" "$LANGUAGE"

--- a/client/oci_env/commands.py
+++ b/client/oci_env/commands.py
@@ -101,6 +101,7 @@ def test(args, client):
 
 def generate_client(args, client):
     api_root = client.get_dynaconf_variable("API_ROOT")
+    container_name = client.container_name(service="pulp")
 
     base_cmd = [
         "bash",
@@ -115,7 +116,7 @@ def generate_client(args, client):
     env = {**os.environ, **client.config, "PULP_API_ROOT": api_root}
 
     for plugin in plugins:
-        cmd = base_cmd + [plugin.replace("-", "_"), args.language]
+        cmd = base_cmd + [plugin.replace("-", "_"), args.language, container_name]
         if args.is_verbose:
             print(f"Running local command: {' '.join(cmd)}")
 


### PR DESCRIPTION
The `generate-client` command was often failing. In my case it had to do with the wrong container name being passed, as podman and docker (compose?) maye different patterns for the container name separators (e.g, `{name}-1 or {name}_1`.

I just used the existing function we have to figure out what's the right one.