### PR TITLE
Update python version to match the new lowerbound python

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,7 +7,7 @@ ENV S6_KEEP_ENV=1
 COPY dev_requirements.txt /dev_requirements.txt
 
 COPY switch_python /usr/bin/switch_python
-ARG PYTHON_VERSION=3.9
+ARG PYTHON_VERSION=3.11
 RUN switch_python "$PYTHON_VERSION"
 
 RUN pip3 install -r dev_requirements.txt

--- a/base/switch_python
+++ b/base/switch_python
@@ -3,8 +3,8 @@
 set -e
 
 NEWV=$1
-if [[ "$NEWV" == "3.9" ]]; then
-    echo "using default python 3.9"
+if [[ "$NEWV" == "3.11" ]]; then
+    echo "using default python 3.11"
     exit 0
 fi
 


### PR DESCRIPTION
To refresh your env this should be enough:

```bash
oci-env compose build
oci-env compose up --force-recreate
```

If not let a comment here with what worked for you.