### PR TITLE
Always install test and client deps by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,7 @@ oci-env -e custom.env compose up
 ### Lint
 
 ```bash
-# Install the lint requirements and run the linter for a specific plugin
-
-oci-env test -i -p PLUGIN_NAME lint
-
-# Run the linter without installing lint dependencies.
+# Install lint requirements and run the linter for a specific plugin
 oci-env test -p PLUGIN_NAME lint
 ```
 
@@ -74,13 +70,10 @@ Ex:
 ```
 
 ```bash
-# Generate the pulp client. This will build clients for all plugins in DEV_SOURCE_PATH. -i will also install the client in the container.
-oci-env generate-client -i
+# Generate and install clients for all plugins in DEV_SOURCE_PATH.
+oci-env generate-client
 
-# Install the functional test requirements and run the tests
-oci-env test -i -p PLUGIN_NAME functional
-
-# Run the tests without installing dependencies.
+# Install functional test requirements and run the tests
 oci-env test -p PLUGIN_NAME functional
 ```
 
@@ -93,7 +86,7 @@ e.g. `oci-env generate-client -l ruby PLUGIN_NAME`.
 
 1. Add "epdb" to the functest_requirements.txt file in your pulp_ansible checkout path.
 2. Inside any functional test, add `import epdb; epdb.st()`.
-3. Re-run `oci-env test -i functional` and `oci-env test -p pulp_ansible functional --capture=no` commands again.
+3. Re-run `oci-env test -p pulp_ansible functional --capture=no`.
 
 #### Using PyCharm remote debug server
 
@@ -123,10 +116,7 @@ The docs are served on the URL logged by the `make servedocs` step.
 ### Unit
 
 ```bash
-# Install the unit test dependencies for a plugin and run it.
-oci-env test -i -p PLUGIN_NAME unit
-
-# Run the unit tests for a plugin without installing test dependencies.
+# Install unit test dependencies and run them for a plugin.
 oci-env test -p PLUGIN_NAME unit
 ```
 

--- a/base/container_scripts/run_functional_tests.sh
+++ b/base/container_scripts/run_functional_tests.sh
@@ -18,10 +18,9 @@ function check_pytest () {
 
 ERROR: pytest is not installed
 
-This usually means you did not include the "-i" flag with the oci-env "test"
-subcommand. The first invocation of functional tests needs "-i" to install the
-test requirements (inc. pytest). After the requirements are installed, "-i" can
-be dropped from further runs on the same container instance.
+This usually means the functional test requirements failed to install. Check that
+functest_requirements.txt exists for the plugin and that "oci-env test -p PLUGIN
+functional" completed the install step successfully.
 EOF
         exit 1
     }
@@ -33,10 +32,8 @@ function check_client () {
 
 ERROR: pulpcore.client.${PROJECT} is missing.
 
-This usually means you did not run "oci-env generate-client -i ${PROJECT}" before
-running the functional test command. It could also mean you did not pass the "-i"
-flag to the "generate-client" subcommand which would have created the client, but
-not install it into the appropriate location.
+This usually means you did not run "oci-env generate-client ${PROJECT}" before
+running the functional test command.
 EOF
         exit 1
     }

--- a/base/container_scripts/run_performance_tests.sh
+++ b/base/container_scripts/run_performance_tests.sh
@@ -17,10 +17,9 @@ function check_pytest () {
 
 ERROR: pytest is not installed
 
-This usually means you did not include the "-i" flag with the oci-env "test"
-subcommand. The first invocation of functional tests needs "-i" to install the
-test requirements (inc. pytest). After the requirements are installed, "-i" can
-be dropped from further runs on the same container instance.
+This usually means the performance test requirements failed to install. Check that
+perftest_requirements.txt or functest_requirements.txt exists for the plugin and
+that "oci-env test -p PLUGIN performance" completed the install step successfully.
 EOF
         exit 1
     }
@@ -32,10 +31,8 @@ function check_client () {
 
 ERROR: pulpcore.client.${PROJECT} is missing.
 
-This usually means you did not run "oci-env generate-client -i ${PROJECT}" before
-running the functional test command. It could also mean you did not pass the "-i"
-flag to the "generate-client" subcommand which would have created the client, but
-not install it into the appropriate location.
+This usually means you did not run "oci-env generate-client ${PROJECT}" before
+running the performance test command.
 EOF
         exit 1
     }

--- a/client/oci_env/commands.py
+++ b/client/oci_env/commands.py
@@ -67,26 +67,25 @@ def shell(args, client):
 
 
 def test(args, client):
-    if args.install_deps:
-        test_script = f"install_{args.test}_requirements.sh"
+    test_script = f"install_{args.test}_requirements.sh"
 
-        if args.plugin:
+    if args.plugin:
+        exit_if_failed(
+            client.exec_container_script(
+                test_script,
+                args=[args.plugin],
+                privileged=args.privileged,
+            ).returncode
+        )
+    else:
+        for project in client.config["DEV_SOURCE_PATH"].split(":"):
             exit_if_failed(
                 client.exec_container_script(
                     test_script,
-                    args=[args.plugin],
+                    args=[project],
                     privileged=args.privileged,
                 ).returncode
             )
-        else:
-            for project in client.config["DEV_SOURCE_PATH"].split(":"):
-                exit_if_failed(
-                    client.exec_container_script(
-                        test_script,
-                        args=[project],
-                        privileged=args.privileged,
-                    ).returncode
-                )
 
     if args.plugin:
         exit_if_failed(
@@ -122,8 +121,12 @@ def generate_client(args, client):
 
         exit_if_failed(subprocess.run(cmd, env=env, cwd=client.path).returncode)
 
-        if args.install_client:
-            exit_if_failed(client.exec_container_script("install_client.sh", args=[plugin.replace("-", "_")]).returncode)
+        if args.language == "python":
+            exit_if_failed(
+                client.exec_container_script(
+                    "install_client.sh", args=[plugin.replace("-", "_")]
+                ).returncode
+            )
 
 
 def pulpcore_manager(args, client):

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -101,9 +101,9 @@ def parse_shell_command(subparsers):
 def parse_test_command(subparsers):
     parser = subparsers.add_parser('test', help='Run tests and install requirements.')
     parser.add_argument('test', choices=["functional", "unit", "lint", "performance"])
-    parser.add_argument('-i', action='store_true', dest='install_deps', help="Install the python dependencies for the selected test instead of running it. If -p is not specified this will install all the test dependencies for each plugin in DEV_SOURCE_PATH.")
+    parser.add_argument('-i', action='store_true', dest='install_deps', help="Deprecated no-op. Test dependencies are always installed.")
     parser.add_argument('-p', type=str, default="", dest='plugin', help="Plugin to test. Tests won't run unless this is specified.")
-    parser.add_argument('args', nargs=argparse.REMAINDER, help='Arguments to pass to pytest.')
+    parser.add_argument('args', nargs=argparse.REMAINDER, help='Arguments to pass to pytest. Use -k/-m to select tests (file paths are not supported with --pyargs).')
     parser.add_argument("--privileged", action="store_true", dest="privileged")
     parser.set_defaults(func=test)
 
@@ -112,7 +112,7 @@ def parse_generate_client_command(subparsers):
     parser = subparsers.add_parser('generate-client', help='Generate the the pulp client.')
     parser.add_argument('plugin', nargs="?", default=None, help="Plugin to generate a client for. If no plugin is specified clients will be generated for all plugins in DEV_SOURCE_PATH.")
     parser.add_argument('-l', '--language', default="python", choices=['python', 'ruby'], help="Language to generate a client for. If no language is specified clients will be generated for python.")
-    parser.add_argument('-i', action='store_true', dest='install_client', help="Install the client after generating it.")
+    parser.add_argument('-i', action='store_true', dest='install_client', help="Deprecated no-op. Python clients are always installed after generating.")
 
     parser.set_defaults(func=generate_client)
 

--- a/docs/dev/guides/run-tests.md
+++ b/docs/dev/guides/run-tests.md
@@ -3,20 +3,14 @@
 ## Lint
 
 ```bash
-# Install the lint requirements and run the linter for a specific plugin
-oci-env test -i -p PLUGIN_NAME lint
-
-# Run the linter without installing lint dependencies.
+# Install lint requirements and run the linter for a specific plugin
 oci-env test -p PLUGIN_NAME lint
 ```
 
 ## Unit
 
 ```bash
-# Install the unit test dependencies for a plugin and run it.
-oci-env test -i -p PLUGIN_NAME unit
-
-# Run the unit tests for a plugin without installing test dependencies.
+# Install unit test dependencies and run them for a plugin.
 oci-env test -p PLUGIN_NAME unit
 ```
 
@@ -32,13 +26,10 @@ Before functional tests can be run, you must clone `github.com/pulp/pulp-openapi
 ```
 
 ```bash
-# Generate the pulp client. This will build clients for all plugins in DEV_SOURCE_PATH. -i will also install the client in the container.
-oci-env generate-client -i
+# Generate and install clients for all plugins in DEV_SOURCE_PATH.
+oci-env generate-client
 
-# Install the functional test requirements and run the tests
-oci-env test -i -p PLUGIN_NAME functional
-
-# Run the tests without installing dependencies.
+# Install functional test requirements and run the tests
 oci-env test -p PLUGIN_NAME functional
 ```
 
@@ -53,7 +44,7 @@ e.g. `oci-env generate-client -l ruby PLUGIN_NAME`.
 
 1. Add "epdb" to the `functest_requirements.txt` file in your pulp_ansible checkout path.
 2. Inside any functional test, add `import epdb; epdb.st()`.
-3. Re-run `oci-env test -i functional` and `oci-env test -p pulp_ansible functional --capture=no` commands again.
+3. Re-run `oci-env test -p pulp_ansible functional --capture=no`.
 
 ### Using PyCharm
 


### PR DESCRIPTION
Make `test` and `generate-client` install packages automatically so `-i` is a no-op, and document using -k/-m to select pytest tests.

With uv now the reinstall of the packages is basically a very fast noop, let's just always install the packages so there's one last flag to specify.