### PR TITLE
Teach client-generation to accept optional api-version.

### DIFF
--- a/base/local_scripts/generate_client.sh
+++ b/base/local_scripts/generate_client.sh
@@ -5,6 +5,8 @@ set -e
 declare PROJECT=$1
 declare LANGUAGE=$2
 declare CONTAINER_NAME=$3  # e.g, oci_env_pulp_1
+declare API_VERSION="${4:-v3}" # e.g. v3
+echo "generate_client ${API_VERSION}"
 
 if [ ! -d "${SRC_DIR}/pulp-openapi-generator/" ]
 then
@@ -22,4 +24,4 @@ export PULP_URL="${API_PROTOCOL}://${API_HOST}:${API_PORT}"
 CONTAINER_LABEL=$("${COMPOSE_BINARY}" container inspect "${CONTAINER_NAME}" | jq -r ".[0].ProcessLabel")
 export PULP_MCS_LABEL="${CONTAINER_LABEL#'system_u:system_r:container_t:'}"
 
-./generate.sh "$PROJECT" "$LANGUAGE"
+./generate.sh "${PROJECT}" "${LANGUAGE}" "${API_VERSION}"

--- a/client/oci_env/commands.py
+++ b/client/oci_env/commands.py
@@ -115,7 +115,7 @@ def generate_client(args, client):
     env = {**os.environ, **client.config, "PULP_API_ROOT": api_root}
 
     for plugin in plugins:
-        cmd = base_cmd + [plugin.replace("-", "_"), args.language, container_name]
+        cmd = base_cmd + [plugin.replace("-", "_"), args.language, container_name, args.api_version]
         if args.is_verbose:
             print(f"Running local command: {' '.join(cmd)}")
 

--- a/client/oci_env/main.py
+++ b/client/oci_env/main.py
@@ -113,6 +113,7 @@ def parse_generate_client_command(subparsers):
     parser.add_argument('plugin', nargs="?", default=None, help="Plugin to generate a client for. If no plugin is specified clients will be generated for all plugins in DEV_SOURCE_PATH.")
     parser.add_argument('-l', '--language', default="python", choices=['python', 'ruby'], help="Language to generate a client for. If no language is specified clients will be generated for python.")
     parser.add_argument('-i', action='store_true', dest='install_client', help="Deprecated no-op. Python clients are always installed after generating.")
+    parser.add_argument('-v', '--api-version', default="v3", choices=['v3', 'v4'], dest='api_version', help="API-version to generate the clients for.")
 
     parser.set_defaults(func=generate_client)
 


### PR DESCRIPTION
Currently accepts v3,v4 and defaults to v3 if not provided.

Assumes the changes from https://github.com/pulp/pulp-openapi-generator/pull/132 are present in pulp-openapi-generator/generate.sh.

https://redhat.atlassian.net/browse/PULP-2219